### PR TITLE
fixed some minor bugs

### DIFF
--- a/src/containers/Organization/Video/RightPanel.jsx
+++ b/src/containers/Organization/Video/RightPanel.jsx
@@ -189,12 +189,12 @@ const RightPanel = ({ currentIndex, currentSubs,setCurrentIndex }) => {
     }
   }, [currentPage]);
 
-  useEffect(() => {
-    const subtitleScrollEle = document.getElementById("subTitleContainer");
-    subtitleScrollEle
-      .querySelector(`#sub_${currentIndex}`)
-      ?.scrollIntoView(true, { block: "start" });
-  }, [currentIndex]);
+  // useEffect(() => {
+  //   const subtitleScrollEle = document.getElementById("subTitleContainer");
+  //   subtitleScrollEle
+  //     .querySelector(`#sub_${currentIndex}`)
+  //     ?.scrollIntoView(true, { block: "start" });
+  // }, [currentIndex]);
 
   const getPayload = (offset = currentOffset, lim = limit) => {
     const payloadObj = new FetchTranscriptPayloadAPI(
@@ -661,7 +661,7 @@ const RightPanel = ({ currentIndex, currentSubs,setCurrentIndex }) => {
                   onClick={() => {
                     if (player) {
                       player.pause();
-                      if (player.duration >= item.startTime) {
+                      if (player.duration >= item.startTime && (player.currentTime < item.startTime || player.currentTime > item.endTime)) {
                         player.currentTime = item.startTime + 0.001;
                       }
                     }


### PR DESCRIPTION
fixes-
1. Currently when they click a card, the display jumps & the selected card is shown on top. Instead, they want the card to be shown as it is. 
2. When a user is on transcription task, and they make some changes to a segment, and then play it again, it starts right from the beginning of that segment instead of the timestamp it was paused at.