### PR TITLE
Replace MUI Links with React Router Links

### DIFF
--- a/src/containers/UserManagement/ForgotPassword.jsx
+++ b/src/containers/UserManagement/ForgotPassword.jsx
@@ -1,11 +1,12 @@
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
+import { Link } from "react-router-dom";
 
 //Styles
 import { LoginStyle } from "styles";
 
 //Components
-import { Grid, Typography, Link, Button } from "@mui/material";
+import { Grid, Typography, Button } from "@mui/material";
 import AppInfo from "./AppInfo";
 import { OutlinedTextField } from "common";
 
@@ -74,7 +75,7 @@ const ForgotPassword = () => {
         </Grid>
         <Grid item xs={12} sm={12} md={12} lg={12} xl={12} textAlign={"right"}>
           <Typography>
-            <Link href="/login"style={{ fontSize: "14px" }}>
+            <Link to="/login" style={{ fontSize: "14px" }}>
               Back to Login
             </Link>
           </Typography>

--- a/src/containers/UserManagement/Login.jsx
+++ b/src/containers/UserManagement/Login.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useNavigate,Link } from "react-router-dom";
 import { translate } from "config";
 
 //Styles
@@ -9,7 +9,7 @@ import { themeDefault } from "theme";
 
 
 //Components
-import { Box, Grid, Link, ThemeProvider, Button } from "@mui/material";
+import { Box, Grid, ThemeProvider, Button } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
 import Visibility from "@mui/icons-material/Visibility";
 import InputAdornment from "@mui/material/InputAdornment";
@@ -172,7 +172,7 @@ const Login = () => {
       <Box display="flex" flexDirection="column" width="100%">
         <Box marginLeft="auto" marginBottom="10px">
           <Link
-            onClick={() => navigate("/forgot-password")}
+            to="/forgot-password"
             style={{ cursor: "pointer" }}
           >
             Forgot Password?


### PR DESCRIPTION
## Description
This PR replaces Material-UI (MUI) Link components with React Router's Link components across the **forgot-password page** and **login page**. This change aims to improve routing consistency for basic navigation.

## Motivation
Currently clicking on `Back to Login` on **forgot password page** which use MUI's Link component with `href='/login'` results in an unhandled endpoint `/login` since **HashRouter** is used for routing.
Using React Router's `Link` component provides better integration with routing sending user back to the login page (`/#/login`).

![chitralekha-Back_to_login-redirect](https://github.com/user-attachments/assets/5f76df48-5ea1-4e93-83a9-0d34e1031563)
